### PR TITLE
Allow manual deploy.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: 'Terraform apply'
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -50,6 +50,7 @@ provider "registry.terraform.io/integrations/github" {
   constraints = "~> 6.2"
   hashes = [
     "h1:Fp0RrNe+w167AQkVUWC1WRAsyjhhHN7aHWUky7VkKW8=",
+    "h1:SapjQ4N+t12K5G93zuO/8GeK+PSrQzR20lBAb+MbE3A=",
     "h1:Yq0DZYKVFwPdc+v5NnXYcgTYWKInSkjv5WjyWMODj9U=",
     "zh:0b1b5342db6a17de7c71386704e101be7d6761569e03fb3ff1f3d4c02c32d998",
     "zh:2fb663467fff76852126b58315d9a1a457e3b04bec51f04bf1c0ddc9dfbb3517",


### PR DESCRIPTION
When the token expires, we need to re-run this to update all the
secrets. This will allow us to do it through GitHub actions.
