### PR TITLE
DR2-2712 Remove unused secrets

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "5.76.0"
   hashes = [
     "h1:3HO1CXuuuWt6dCfSYO4tBJjaNh86hd8M2ldzAAN1LTs=",
+    "h1:JSLR3JP9naVcnH0PHcDwwHr3aQB9vlW0+b8HQma1GpU=",
     "zh:05b2a0d25fc07576f6698d4840d0d2ae2599484c49f1b911ea1154584557bc13",
     "zh:1b22dd1d9c482739e133adb996a9c8b285ca7d978d0fe04deaa5588eba5d254c",
     "zh:216088c8800e7b8d7eff7b1a822317bc6faec64f27946ffd22bb3494ac4175cb",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/github" {
   version = "6.3.1"
   hashes = [
     "h1:2Ys7Qpr5NuWWUk9mmvQlejdF1rMN8GB8hTOPEprekS0=",
+    "h1:kNCbU7jr9j09hqWwyXGFDN95Un28gWO2kY2yImv1MDY=",
     "zh:25ae1cb97ec528e6b7e9330489f4a33acc0fa80b909c113a8445656bc524c5b9",
     "zh:3e1f6300dc10e52a54f13352770ed79f25ff4ba9ac49b776c52a655a3488a20b",
     "zh:4aaf2877ec22e63358d7c9cd48c7d7947d1a1dc4d03231f0af193d8975d5918a",

--- a/root.tf
+++ b/root.tf
@@ -16,18 +16,6 @@ module "github_preservica_client_repository" {
   }
 }
 
-
-module "dr2_github_actions_scala_steward" {
-  source          = "git::https://github.com/nationalarchives/da-terraform-modules//github_repository_secrets"
-  repository_name = "nationalarchives/dr2-github-actions"
-  secrets = {
-    WORKFLOW_TOKEN  = data.aws_ssm_parameter.github_workflow_token.value
-    GPG_KEY_ID      = data.aws_ssm_parameter.github_gpg_key_id.value
-    GPG_PRIVATE_KEY = data.aws_ssm_parameter.github_gpg_key.value
-    GPG_PASSPHRASE  = data.aws_ssm_parameter.github_gpg_passphrase.value
-  }
-}
-
 module "custodial_copy" {
   source          = "git::https://github.com/nationalarchives/da-terraform-modules//github_repository_secrets"
   repository_name = "nationalarchives/dr2-custodial-copy"
@@ -35,105 +23,9 @@ module "custodial_copy" {
     MANAGEMENT_ACCOUNT = data.aws_caller_identity.current.account_id
     SLACK_WEBHOOK      = data.aws_ssm_parameter.github_slack_webhook.value
     WORKFLOW_TOKEN     = data.aws_ssm_parameter.github_workflow_token.value
+    GPG_KEY_ID         = data.aws_ssm_parameter.github_gpg_key_id.value
     GPG_PRIVATE_KEY    = data.aws_ssm_parameter.github_gpg_key.value
     GPG_PASSPHRASE     = data.aws_ssm_parameter.github_gpg_passphrase.value
-  }
-}
-
-locals {
-  account_secrets = {
-    for environment, _ in module.configuration.account_numbers : environment => {
-      "DR2_${upper(environment)}_ACCOUNT_NUMBER"        = module.configuration.account_numbers[environment]
-      "DR2_${upper(environment)}_TERRAFORM_ROLE"        = module.configuration.terraform_config[environment]["terraform_account_role"]
-      "DR2_${upper(environment)}_CUSTODIAN_ROLE"        = module.configuration.terraform_config[environment]["custodian_role"]
-      "DR2_${upper(environment)}_STATE_BUCKET"          = module.configuration.terraform_config[environment]["state_bucket"]
-      "DR2_${upper(environment)}_DYNAMO_TABLE"          = module.configuration.terraform_config[environment]["dynamo_table"]
-      "DR2_${upper(environment)}_TERRAFORM_EXTERNAL_ID" = module.configuration.terraform_config[environment]["terraform_external_id"]
-    }
-  }
-}
-
-module "terraform_environments_repository" {
-  source          = "git::https://github.com/nationalarchives/da-terraform-modules//github_repository_secrets"
-  repository_name = "nationalarchives/dr2-terraform-environments"
-  secrets = merge(local.account_secrets["intg"], local.account_secrets["staging"], local.account_secrets["prod"], local.account_secrets["mgmt"], {
-    DR2_MANAGEMENT_ACCOUNT = data.aws_caller_identity.current.account_id
-    DR2_SLACK_WEBHOOK      = data.aws_ssm_parameter.github_slack_webhook.value
-    DR2_WORKFLOW_PAT       = data.aws_ssm_parameter.github_workflow_token.value
-  })
-}
-
-module "terraform_environments_repository_environments" {
-  for_each              = module.configuration.account_numbers
-  source                = "git::https://github.com/nationalarchives/da-terraform-modules//github_environment_secrets"
-  environment           = each.key
-  repository_name       = "nationalarchives/dr2-terraform-environments"
-  team_slug             = "digital-records-repository"
-  integration_team_slug = ["digital-records-repository"]
-  secrets = {
-    ACCOUNT_NUMBER = each.value
-  }
-}
-
-module "github_tna_custodian_repository" {
-  source          = "git::https://github.com/nationalarchives/da-terraform-modules//github_repository_secrets"
-  repository_name = "nationalarchives/tna-custodian"
-  secrets = merge(local.account_secrets["intg"], local.account_secrets["staging"], local.account_secrets["prod"], local.account_secrets["mgmt"], {
-    DR2_MANAGEMENT_ACCOUNT = data.aws_caller_identity.current.account_id
-    DR2_SLACK_WEBHOOK      = data.aws_ssm_parameter.github_slack_webhook.value
-    DR2_WORKFLOW_PAT       = data.aws_ssm_parameter.github_workflow_token.value
-    DR2_EMAIL_ADDRESS      = module.configuration.terraform_config["notification_email"]
-  })
-}
-
-module "tna_custodian_repository_environments" {
-  for_each              = module.configuration.account_numbers
-  source                = "git::https://github.com/nationalarchives/da-terraform-modules//github_environment_secrets"
-  environment           = "dr2-${each.key}"
-  repository_name       = "nationalarchives/tna-custodian"
-  team_slug             = "digital-records-repository"
-  integration_team_slug = ["digital-records-repository"]
-}
-
-module "github_tna_aws_accounts_repository" {
-  source          = "git::https://github.com/nationalarchives/da-terraform-modules//github_repository_secrets"
-  repository_name = "nationalarchives/tdr-aws-accounts"
-  secrets = merge(local.account_secrets["intg"], local.account_secrets["staging"], local.account_secrets["prod"], local.account_secrets["mgmt"], {
-    DR2_MANAGEMENT_ACCOUNT = data.aws_caller_identity.current.account_id
-    DR2_SLACK_WEBHOOK      = data.aws_ssm_parameter.github_slack_webhook.value
-    DR2_WORKFLOW_PAT       = data.aws_ssm_parameter.github_workflow_token.value
-    DR2_EMAIL_ADDRESS      = module.configuration.terraform_config["notification_email"]
-  })
-}
-
-module "tna_aws_accounts_repository_environments" {
-  for_each              = module.configuration.account_numbers
-  source                = "git::https://github.com/nationalarchives/da-terraform-modules//github_environment_secrets"
-  environment           = "dr2-${each.key}"
-  repository_name       = "nationalarchives/tdr-aws-accounts"
-  team_slug             = "digital-records-repository"
-  integration_team_slug = ["digital-records-repository"]
-}
-
-module "court_document_package_anonymiser" {
-  source          = "git::https://github.com/nationalarchives/da-terraform-modules//github_repository_secrets"
-  repository_name = "nationalarchives/dr2-court-document-package-anonymiser"
-  secrets = {
-    SLACK_WEBHOOK             = data.aws_ssm_parameter.github_slack_webhook.value
-    WORKFLOW_TOKEN            = data.aws_ssm_parameter.github_workflow_token.value
-    MANAGEMENT_ACCOUNT_NUMBER = data.aws_caller_identity.current.account_id
-  }
-}
-
-module "court_document_package_anonymiser_environments" {
-  for_each              = module.configuration.account_numbers
-  source                = "git::https://github.com/nationalarchives/da-terraform-modules//github_environment_secrets"
-  environment           = each.key
-  repository_name       = "nationalarchives/dr2-court-document-package-anonymiser"
-  team_slug             = "digital-records-repository"
-  integration_team_slug = []
-  secrets = {
-    ACCOUNT_NUMBER = each.value
   }
 }
 
@@ -144,6 +36,9 @@ module "dr2_ingest" {
     MANAGEMENT_ACCOUNT = data.aws_caller_identity.current.account_id
     SLACK_WEBHOOK      = data.aws_ssm_parameter.github_slack_webhook.value
     WORKFLOW_TOKEN     = data.aws_ssm_parameter.github_workflow_token.value
+    GPG_KEY_ID         = data.aws_ssm_parameter.github_gpg_key_id.value
+    GPG_PRIVATE_KEY    = data.aws_ssm_parameter.github_gpg_key.value
+    GPG_PASSPHRASE     = data.aws_ssm_parameter.github_gpg_passphrase.value
   }
 }
 

--- a/root.tf
+++ b/root.tf
@@ -95,11 +95,12 @@ module "github_aws_clients_repository" {
   source          = "git::https://github.com/nationalarchives/da-terraform-modules//github_repository_secrets"
   repository_name = "nationalarchives/da-aws-clients"
   secrets = {
-    WORKFLOW_TOKEN    = data.aws_ssm_parameter.github_workflow_token.value
-    SLACK_WEBHOOK     = data.aws_ssm_parameter.github_slack_webhook.value
-    SONATYPE_USERNAME = data.aws_ssm_parameter.github_sonatype_username.value
-    SONATYPE_PASSWORD = data.aws_ssm_parameter.github_sonatype_password.value
-    GPG_PRIVATE_KEY   = data.aws_ssm_parameter.github_gpg_key.value
-    GPG_PASSPHRASE    = data.aws_ssm_parameter.github_gpg_passphrase.value
+    WORKFLOW_TOKEN     = data.aws_ssm_parameter.github_workflow_token.value
+    SLACK_WEBHOOK      = data.aws_ssm_parameter.github_slack_webhook.value
+    SONATYPE_USERNAME  = data.aws_ssm_parameter.github_sonatype_username.value
+    SONATYPE_PASSWORD  = data.aws_ssm_parameter.github_sonatype_password.value
+    GPG_PRIVATE_KEY    = data.aws_ssm_parameter.github_gpg_key.value
+    GPG_PASSPHRASE     = data.aws_ssm_parameter.github_gpg_passphrase.value
+    MANAGEMENT_ACCOUNT = data.aws_caller_identity.current.account_id
   }
 }

--- a/root.tf
+++ b/root.tf
@@ -90,3 +90,16 @@ module "dr2-farm-survey" {
     WORKFLOW_TOKEN = data.aws_ssm_parameter.github_workflow_token.value
   }
 }
+
+module "github_aws_clients_repository" {
+  source          = "git::https://github.com/nationalarchives/da-terraform-modules//github_repository_secrets"
+  repository_name = "nationalarchives/da-aws-clients"
+  secrets = {
+    WORKFLOW_TOKEN    = data.aws_ssm_parameter.github_workflow_token.value
+    SLACK_WEBHOOK     = data.aws_ssm_parameter.github_slack_webhook.value
+    SONATYPE_USERNAME = data.aws_ssm_parameter.github_sonatype_username.value
+    SONATYPE_PASSWORD = data.aws_ssm_parameter.github_sonatype_password.value
+    GPG_PRIVATE_KEY   = data.aws_ssm_parameter.github_gpg_key.value
+    GPG_PASSPHRASE    = data.aws_ssm_parameter.github_gpg_passphrase.value
+  }
+}

--- a/root.tf
+++ b/root.tf
@@ -7,12 +7,13 @@ module "github_preservica_client_repository" {
   source          = "git::https://github.com/nationalarchives/da-terraform-modules//github_repository_secrets"
   repository_name = "nationalarchives/dr2-preservica-client"
   secrets = {
-    WORKFLOW_TOKEN    = data.aws_ssm_parameter.github_workflow_token.value
-    SLACK_WEBHOOK     = data.aws_ssm_parameter.github_slack_webhook.value
-    SONATYPE_USERNAME = data.aws_ssm_parameter.github_sonatype_username.value
-    SONATYPE_PASSWORD = data.aws_ssm_parameter.github_sonatype_password.value
-    GPG_PRIVATE_KEY   = data.aws_ssm_parameter.github_gpg_key.value
-    GPG_PASSPHRASE    = data.aws_ssm_parameter.github_gpg_passphrase.value
+    MANAGEMENT_ACCOUNT = data.aws_caller_identity.current.account_id
+    WORKFLOW_TOKEN     = data.aws_ssm_parameter.github_workflow_token.value
+    SLACK_WEBHOOK      = data.aws_ssm_parameter.github_slack_webhook.value
+    SONATYPE_USERNAME  = data.aws_ssm_parameter.github_sonatype_username.value
+    SONATYPE_PASSWORD  = data.aws_ssm_parameter.github_sonatype_password.value
+    GPG_PRIVATE_KEY    = data.aws_ssm_parameter.github_gpg_key.value
+    GPG_PASSPHRASE     = data.aws_ssm_parameter.github_gpg_passphrase.value
   }
 }
 


### PR DESCRIPTION
I've removed the scala steward ones but also some unused repos as well.

I've added the gpg keys to the ingest repo so it can run scala steward
on its own.

I've also added the da-aws-clients secrets to this repo so we can delete this one https://github.com/nationalarchives/da-terraform-github-repositories
